### PR TITLE
Remove the failing livefyre healthcheck

### DIFF
--- a/app/health/config.json
+++ b/app/health/config.json
@@ -5,7 +5,6 @@
 	"description": "comment-creation-service",
 	"checks": [
 		"db",
-		"livefyreApi",
 		"suds"
 	]
 }


### PR DESCRIPTION
Right now this is failing and it is causing no noticable production
issues. Removing it so its not an issue for ops whilst we try and work
on a fix or if its even needed.